### PR TITLE
Allow clean to fail silently

### DIFF
--- a/lib/sfizio/clean/clean.rb
+++ b/lib/sfizio/clean/clean.rb
@@ -4,17 +4,30 @@ module Sfizio
     class Clean
         attr_reader :tap_path
         attr_reader :brewfile
-        def initialize(tap_path, brewfile)
+        attr_reader :logger
+        
+        def initialize(tap_path, brewfile, logger)
             @tap_path = tap_path
             @brewfile = brewfile
+            @logger = logger
         end
 
         def clean!
             if brewfile
-                brewfile.formulas.each { |f| Sfizio::Brew::Uninstall.formula(f.local_tap_path) }
+                brewfile.formulas.each do |f|
+                    begin
+                        Sfizio::Brew::Uninstall.formula(f.local_tap_path)
+                    rescue StandardError => exception
+                        logger.debug("Couldn't uninstall #{f.local_tap_path}")
+                    end
+                end
             end
 
-            Sfizio::Brew::Tap.untap(tap_path, force: true)
+            begin
+                Sfizio::Brew::Tap.untap(tap_path, force: true)
+            rescue StandardError => exception
+                logger.debug("Couldn't untap local tap path.")
+            end
         end
     end
 end

--- a/lib/sfizio/command.rb
+++ b/lib/sfizio/command.rb
@@ -33,7 +33,7 @@ module Sfizio
                     logger.debug("Loading Brewfile from #{brewfile_path}")
                     brewfile = Sfizio::Brewfile.from_file(brewfile_path)
                 end
-                Sfizio::Clean.new(TAP_PATH, brewfile).clean!
+                Sfizio::Clean.new(TAP_PATH, brewfile, logger).clean!
             when "help"
                 puts "sfizio [command] <option>\n\nCommands:\ninstall, clean\n\nOptions:\n-v Verbose output\n--update Updates formulas. Only supports the install command."
             else

--- a/spec/sfizio/clean/clean_spec.rb
+++ b/spec/sfizio/clean/clean_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe Sfizio::Clean do
+  let(:test_logger) { Logger.new('/dev/null') }
+
   context 'when clean is invoked with a Brewfile' do
     let(:brewfile) { Sfizio::Brewfile.new([Sfizio::Formula.new('cloc', '2.9', nil)]) }
-    let(:cleaner) { described_class.new(Sfizio::TAP_PATH, brewfile) }
+    let(:cleaner) { described_class.new(Sfizio::TAP_PATH, brewfile, test_logger) }
     it 'uninstalls all Brewfile formula' do
       allow(Sfizio::Brew::Tap).to receive(:untap).and_return(nil)
       expect(Sfizio::Brew::Uninstall).to receive(:formula).with("#{Sfizio::TAP_PATH}/cloc@2.9").and_return(nil)
@@ -15,10 +17,22 @@ describe Sfizio::Clean do
       allow(Sfizio::Brew::Uninstall).to receive(:formula).and_return(nil)
       cleaner.clean!
     end
+
+    it 'still cleans if uninstall fails' do
+      allow(Sfizio::Brew::Uninstall).to receive(:formula).and_raise("Failed")
+      allow(Sfizio::Brew::Tap).to receive(:untap).and_return(nil)
+      cleaner.clean!
+    end
+
+    it 'still cleans if untap and uninstall fails' do
+      allow(Sfizio::Brew::Uninstall).to receive(:formula).and_raise("Failed")
+      allow(Sfizio::Brew::Tap).to receive(:untap).and_raise("Failed")
+      cleaner.clean!
+    end
   end
 
   context 'when clean is invoked without a Brewfile' do
-    let(:cleaner) { described_class.new(Sfizio::TAP_PATH, nil) }
+    let(:cleaner) { described_class.new(Sfizio::TAP_PATH, nil, test_logger) }
 
     it 'accepts a nil Brewfile' do
       expect(Sfizio::Brew::Tap).to receive(:untap).with(Sfizio::TAP_PATH, force: true).and_return(nil)

--- a/spec/sfizio/command_spec.rb
+++ b/spec/sfizio/command_spec.rb
@@ -18,7 +18,8 @@ describe Sfizio::Command do
       command.run!
     end
 
-    it 'fails unknown commands' do      
+    it 'fails unknown commands' do    
+      allow($stdout).to receive(:write)  
       command = described_class.new(['unknown'])
       begin
         command.run!


### PR DESCRIPTION
Cleanup should try to remove as much state as possible, but should rescue any problems due to formulas not existing or the tap already being removed. This enables us to run `sfizio clean` over and over without any exceptions being thrown.